### PR TITLE
[RTL-1864] Expose printer type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posify"
-version = "0.6.10"
+version = "0.6.11"
 description = """
 An thermal printer driver for Rust
 """

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -144,7 +144,7 @@ pub struct UsbInfo {
 pub struct Printer {
     codec: EncodingRef,
     trap: EncoderTrap,
-    printer: SupportedPrinters,
+    pub printer: SupportedPrinters,
     _device: rusb::Device<rusb::GlobalContext>,
     handle: rusb::DeviceHandle<rusb::GlobalContext>,
     descriptor: rusb::DeviceDescriptor,


### PR DESCRIPTION
This just makes it much easier to work with the printer templates as the printers do need very slightly different templates.