### PR TITLE
Added firmware checksum and id get functions for Epic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "posify"
-version = "0.6.12"
+version = "0.6.13"
 description = """
 An thermal printer driver for Rust
 """

--- a/examples/get_firmware.rs
+++ b/examples/get_firmware.rs
@@ -1,0 +1,16 @@
+use posify::printer::{Printer, SupportedPrinters};
+
+fn main() {
+    let vid: u16 = 0x0613;
+    let pid: u16 = 0x8800;
+
+    let mut printer = Printer::new(None, None, SupportedPrinters::Epic, vid, pid).unwrap();
+
+    let value = printer.get_firmware_checksum().unwrap();
+
+    println!("firmware_version: {:?}", value.to_string());
+
+    let value = printer.get_firmware_id().unwrap();
+
+    println!("firmware_id: {:?}", value.to_string());
+}


### PR DESCRIPTION
This only works for Epic, other printers are Unsupported. Retrieves the 4 byte checksum and 14 byte firmware ID, truncating their command IDs and formatting them as a bit-string for checksum and string for id.

Adds an example for retrieving these values outside of an application context.

![image](https://github.com/flynnguy/posify/assets/2084367/bdd0fb49-823c-4b43-a246-45fdd4f0d01e)
